### PR TITLE
Добавлен метод для показа алерта под фильтры

### DIFF
--- a/FakeNFT/Resources/Localizable.strings
+++ b/FakeNFT/Resources/Localizable.strings
@@ -4,3 +4,8 @@
 "Error.unknown" = "Произошла неизвестная ошибка";
 "Error.repeat" = "Повторить";
 "Error.title" = "Ошибка";
+
+
+//Filter actionSheet
+"Filter.actionSheet.title" = "Сортировка";
+"Filter.actionSheet.closeButton.text" = "Закрыть";

--- a/FakeNFT/Scenes /Common/Protocols/ErrorView.swift
+++ b/FakeNFT/Scenes /Common/Protocols/ErrorView.swift
@@ -25,4 +25,35 @@ extension ErrorView where Self: UIViewController {
         alert.addAction(action)
         present(alert, animated: true)
     }
+    
+    func showFilterActionSheet(firstAction: UIAlertAction, secondAction: UIAlertAction, thirdAction: UIAlertAction?) {
+        let titleOfActionSheet = NSLocalizedString("Filter.actionSheet.title", comment: "")
+        
+        let alert = UIAlertController(
+            title: titleOfActionSheet,
+            message: nil,
+            preferredStyle: .actionSheet
+        )
+        
+        let textOfCancelButton = NSLocalizedString("Filter.actionSheet.closeButton.text", comment: "")
+        let cancelAction = UIAlertAction(title: textOfCancelButton, style: .cancel)
+        
+        if let thirdAction = thirdAction {
+            [firstAction, secondAction, thirdAction, cancelAction].forEach { alert.addAction($0) }
+        } else {
+            [firstAction, secondAction, cancelAction].forEach { alert.addAction($0) }
+        }
+        
+        if let popover = alert.popoverPresentationController {
+            popover.sourceView = self.view
+            popover.sourceRect = CGRect(
+                x: self.view.bounds.midX,
+                y: self.view.bounds.midY,
+                width: 0,
+                height: 0)
+            popover.permittedArrowDirections = []
+        }
+        
+        present(alert, animated: true)
+    }
 }


### PR DESCRIPTION
develope(newFeature): Добавлен метод для показа алерта под фильтры

Выполнены следующие работы:
1) В Localizable добавлено две строки для заголовка("Filter.actionSheet.title") алерта и для кнопки закрыть ("Filter.actionSheet.closeButton.text"); 2) В ErrorView добавлен метод для показа алерта под фильтры (подходит для алерта с двумя или с тремя кнопками).